### PR TITLE
fix: demo-manager default nginx rooting

### DIFF
--- a/.dockerfiles/platform-manager-demo/Dockerfile.demo
+++ b/.dockerfiles/platform-manager-demo/Dockerfile.demo
@@ -4,6 +4,7 @@ RUN rm /usr/share/nginx/html/index.html \
     && apk update && apk add -u gettext
 
 COPY ./apps/vendor-portal/dist /usr/share/nginx/html
+COPY ./.dockerfiles/platform-manager-demo/nginx.default.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 

--- a/.dockerfiles/platform-manager-demo/nginx.default.conf
+++ b/.dockerfiles/platform-manager-demo/nginx.default.conf
@@ -1,0 +1,21 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
## Scope of work
Added default rooting to the container level (all requests will send to the /index)


